### PR TITLE
Do not inspect HTTP_X_FORWARDED_PROTO

### DIFF
--- a/sslify/middleware.py
+++ b/sslify/middleware.py
@@ -10,7 +10,7 @@ class SSLifyMiddleware(object):
         This will only take effect if ``settings.DEBUG`` is False.
     """
     def process_request(self, request):
-        if not any((settings.DEBUG, request.is_secure()):
+        if not any((settings.DEBUG, request.is_secure())):
             url = request.build_absolute_uri(request.get_full_path())
             secure_url = url.replace('http://', 'https://')
             return HttpResponsePermanentRedirect(secure_url)


### PR DESCRIPTION
quoted from the original ticket author at my `django-sslify-admin` repo:
_Currently, `HTTP_X_FORWARDED_PROTO` is always inspected. However; this header can be faked. As noted by the devs of django, you should be very explicit with such options:  https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header. It think that the check should be removed and force users to set their `SECURE_PROXY_SSL_HEADER` correctly._

please check this https://github.com/return1/django-sslify-admin/issues/1 ticket for credits to the original bug hunter.
