### PR TITLE
Added a pep compliant version numbering scheme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,15 @@ from os.path import abspath, dirname, join, normpath
 
 from setuptools import setup
 
+from sslify import __version__
+
 
 setup(
 
     # Basic package information:
     name = 'django-sslify',
-    version = '0.2',
+    version = __version__,
+ 
     packages = ('sslify',),
 
     # Packaging options:

--- a/sslify/__init__.py
+++ b/sslify/__init__.py
@@ -1,0 +1,8 @@
+version = (0, 2, 1)
+
+
+def get_version():
+    """returns a pep compliant version number"""
+    return '.'.join(str(i) for i in version)
+
+__version__ = get_version()


### PR DESCRIPTION
Hello,

This is the first of a few PR's I'll be doing on this - this one simply puts a PEP compliant version number approach.  
- put the version into `sslify.__init__` as a tuple
- added a simple function to construct version number from tuple
- assigned output of function to `__version__` variable
- updated `setup.py` to use the variable containing the version rather than have it hardcoded in two places.

Nice work.

Cheers, 

Jamie.
