### PR TITLE
Could not run tests in development environment without this change

### DIFF
--- a/sslify/tests.py
+++ b/sslify/tests.py
@@ -11,14 +11,15 @@ class SSLifyMiddlware(TestCase):
         self.factory = RequestFactory()
 
     def test_perma_redirects_http_to_https(self):
-        request = self.factory.get('/woot/')
-        self.assertTrue(request.build_absolute_uri().startswith('http://'))
+        with self.settings(SSLIFY_DISABLE=False):
+            request = self.factory.get('/woot/')
+            self.assertTrue(request.build_absolute_uri().startswith('http://'))
 
-        middleware = _SSLifyMiddleware()
-        request = middleware.process_request(request)
+            middleware = _SSLifyMiddleware()
+            request = middleware.process_request(request)
 
-        self.assertIsInstance(request, HttpResponsePermanentRedirect)
-        self.assertTrue(request['Location'].startswith('https://'))
+            self.assertIsInstance(request, HttpResponsePermanentRedirect)
+            self.assertTrue(request['Location'].startswith('https://'))
 
     def test_disable_for_tests(self):
         """If disabled, we get a 404"""


### PR DESCRIPTION
I wanted to run the tests in my development environment in which I have `SSLIFY_DISABLE = True`, but would get an error because None is not an instance of HttpResponsePermanentRedirect.
