### PR TITLE
Remove Python 2.6 from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"


### PR DESCRIPTION
Python 2.6 is no longer supported by Django 1.7, causing the travis-ci tests to fail for that platform.

An alternative to removing this completely is to use the Travis-CI matrix feature to test against multiple Django/Python versions. See an example here:
https://github.com/sesh/tidbits/blob/master/.travis.yml
