### PR TITLE
Fixed test for 1.9 & refactoring.

### DIFF
--- a/sslify/middleware.py
+++ b/sslify/middleware.py
@@ -21,7 +21,8 @@ class SSLifyMiddleware(object):
         You can also disable this middleware when testing by setting
         ``settings.SSLIFY_DISABLE`` to True.
     """
-    def process_request(self, request):
+    @staticmethod
+    def process_request(request):
         # If the user has explicitly disabled SSLify, do nothing.
         if getattr(settings, 'SSLIFY_DISABLE', False):
             return None

--- a/sslify/tests.py
+++ b/sslify/tests.py
@@ -15,7 +15,7 @@ from django.test.client import RequestFactory
 from sslify.middleware import SSLifyMiddleware
 
 
-class SSLifyMiddlwareTest(TestCase):
+class SSLifyMiddlewareTest(TestCase):
 
     def setUp(self):
         self.factory = RequestFactory()
@@ -24,7 +24,7 @@ class SSLifyMiddlwareTest(TestCase):
         request = self.factory.get('/woot/')
         self.assertTrue(request.build_absolute_uri().startswith('http://'))
 
-        middleware = SSLifyMiddleware()
+        middleware = SSLifyMiddleware
         result = middleware.process_request(request)
 
         self.assert_https_redirect(result)
@@ -34,7 +34,7 @@ class SSLifyMiddlwareTest(TestCase):
         custom_port = 8443
         with self.settings(SSLIFY_PORT=custom_port):
             request = self.factory.get('/woot/')
-            middleware = SSLifyMiddleware()
+            middleware = SSLifyMiddleware
             request = middleware.process_request(request)
 
             self.assertEqual(custom_port, urlsplit(request['Location']).port)
@@ -49,7 +49,7 @@ class SSLifyMiddlwareTest(TestCase):
             return request.get_full_path().startswith('/disabled')
 
         with self.settings(SSLIFY_DISABLE_FOR_REQUEST=[sslify_disable]):
-            middleware = SSLifyMiddleware()
+            middleware = SSLifyMiddleware
             request = self.factory.get('/disabled/')
             request = middleware.process_request(request)
             self.assertIsNone(request)

--- a/test_project/templates.py
+++ b/test_project/templates.py
@@ -1,4 +1,11 @@
-from django.template.base import TemplateDoesNotExist
+
+try:
+    # Django == 1.9
+    from django.template import TemplateDoesNotExist
+except:
+    # Django >= 1.8
+    from django.template.base import TemplateDoesNotExist
+
 try:
     # Django >= 1.8
     # https://docs.djangoproject.com/en/1.8/releases/1.8/#django-template-loader-baseloader


### PR DESCRIPTION
I was getting this error message when running the tests on 1.9:

File "/GitHub/django-sslify/test_project/templates.py", line 1, in <module>
    from django.template.base import TemplateDoesNotExist
ImportError: cannot import name TemplateDoesNotExist

I fixed this by adding a new try/catch block in the test_project.

I've also declared the process_request method in the middleware module as static since it wasn't referring back to the class.

I've ran the tests against django 1.9, 1.8, and 1.7 and all passed.

