### PR TITLE
Add Django 1.8 info to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ If you are using Heroku, you may need to add ``SECURE_PROXY_SSL_HEADER`` as well
     SECURE_SSL_REDIRECT = True
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
-Django's documentation includes more details about [security settings for HTTPS](https://docs.djangoproject.com/en/dev/topics/security/#ssl-https).
+Django's documentation includes more details about `security settings for HTTPS<https://docs.djangoproject.com/en/dev/topics/security/#ssl-https>`.
 
 If you are using an older version of Django (1.7 or earlier), then this package is for you.
 

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,27 @@ The goal of this project is to make it easy for people to force HTTPS on every
 page of their Django site, API, web app, or whatever you're building.  Securing
 your site shouldn't be hard.
 
+Using Django 1.8 or later?
+--------------------------
+
+This package was written before Django 1.8. If you are using Django 1.8 or later, you do not need this library in order to force HTTPS. Instead, you can just change your ``settings.py`` file to include ``SECURE_SSL_REDIRECT``.
+
+.. code-block:: python
+
+    # in settings.py
+    SECURE_SSL_REDIRECT = True
+
+If you are using Heroku, you may need to add ``SECURE_PROXY_SSL_HEADER`` as well.
+
+.. code-block:: python
+
+    # in settings.py
+    SECURE_SSL_REDIRECT = True
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+Django's documentation includes more details about [security settings for HTTPS](https://docs.djangoproject.com/en/dev/topics/security/#ssl-https).
+
+If you are using an older version of Django (1.7 or earlier), then this package is for you.
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ If you are using Heroku, you may need to add ``SECURE_PROXY_SSL_HEADER`` as well
     SECURE_SSL_REDIRECT = True
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
-Django's documentation includes more details about `security settings for HTTPS<https://docs.djangoproject.com/en/dev/topics/security/#ssl-https>`.
+Django's documentation includes more details about `security settings for HTTPS <https://docs.djangoproject.com/en/dev/topics/security/#ssl-https>`_.
 
 If you are using an older version of Django (1.7 or earlier), then this package is for you.
 


### PR DESCRIPTION
As noted in https://github.com/rdegges/django-sslify/issues/31, if someone is using Django >= 1.8, they probably don't need this library. Since Django is now at 1.10, I thought it might be a good idea to mention this in a prominent place in the README, and to provide some quick tips on using equivalent functionality through Django's settings.